### PR TITLE
updates to fix small bug and also run tree analyzer over iso collection

### DIFF
--- a/IsoVertexIDAnalyzer/plugins/IsoVertexIDTreeAnalyzer.cc
+++ b/IsoVertexIDAnalyzer/plugins/IsoVertexIDTreeAnalyzer.cc
@@ -315,6 +315,7 @@ IsoVertexIDTreeAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
        {
          tp = recSimColl[trk];
          mtp = tp.begin()->first.get();
+         if(mtp->eventId().bunchCrossing()!=0) continue;
          trk2EvtMap.insert(std::pair<long, int>( trkIdMaker(trk->pt(), trk->eta(), trk->phi(), trk->vz(), trk->chi2() ) , mtp->eventId().event())  );
          //std::cout << mtp->eventId().event() << std::endl;
        }

--- a/IsoVertexIDAnalyzer/test/vertextree_mc_cfg.py
+++ b/IsoVertexIDAnalyzer/test/vertextree_mc_cfg.py
@@ -2,10 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("vertex")
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.MessageLogger.cerr.FwkReport.reportEvery = 2000
+process.MessageLogger.cerr.FwkReport.reportEvery = 500
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(1000)
+    input = cms.untracked.int32(-1)
 )
 
 #Trigger Selection
@@ -47,7 +47,7 @@ process.source = cms.Source("PoolSource",
 #'root://cms-xrd-global.cern.ch//store/mc/RunIISummer16DR80/MinBias_TuneCUETP8M1_13TeV-pythia8/AODSIM/NoPU_80X_mcRun2_asymptotic_v14-v1/90000/F6F8F73B-C773-E611-994B-FA163EF5B328.root'
 #/QCD_pThat-15_Dijet_TuneCP5_5p02TeV_pythia8/clindsey-RECODEBUG_5M_20190809-1728443825029465ed1ddcc6bf2afd0a/USER ----- pthat 15 2017 5 TeV reference pp MC w/ RECODEBUG info on phys03 (pileup is poisson of exactly 2)
 #'file://step3.root'     
-'file:///storage1/users/aab9/PileupFlow_Feb2_FEVTDEBUG/step3_Poisson15.root'
+'file:///storage1/users/aab9/PileupFlow_Feb2_FEVTDEBUG/step3_Poisson5.root'
            )
 #                                secondaryFileNames = cms.untracked.vstring('')
                             )
@@ -74,6 +74,11 @@ process.TrkAssociationSequence = cms.Sequence(
 process.load("IsoVertexIDAnalysis.IsoVertexIDAnalyzer.vertextree_cff")
 process.vertextree_ana.isMC = cms.bool(True)
 
+#run analyzer on isolated collection
+process.vertextree_iso_ana = process.vertextree_ana.clone()
+process.vertextree_iso_ana.VertexCollection = cms.InputTag('isolatedOfflinePrimaryVertices')
+
+process.load("IsoVertexIDAnalysis.IsoVertexIDProducer.isolatedOfflinePrimaryVertices_cff")
 
 process.options = cms.untracked.PSet(
     wantSummary = cms.untracked.bool(True)
@@ -81,7 +86,7 @@ process.options = cms.untracked.PSet(
 
 # Additional output definition
 process.TFileService = cms.Service("TFileService",
-                                   fileName = cms.string('vertextree_Poisson15.root')
+                                   fileName = cms.string('vertextree_Poisson5_wIso.root')
                                    )
 
-process.ana = cms.Path(process.eventFilter_HM * process.TrkAssociationSequence * process.vertextree_ana)
+process.ana = cms.Path(process.eventFilter_HM * process.TrkAssociationSequence * process.vertextree_ana * process.isolatedOfflinePrimaryVertices * process.vertextree_iso_ana )

--- a/Visualization/visualize.C
+++ b/Visualization/visualize.C
@@ -14,6 +14,7 @@ void visualization(int eventNumber, std::string fileName, std::string tag = "", 
 
   TFile * f = TFile::Open(fileName.c_str(),"read");
   TTree * t = (TTree*)f->Get("vertextree_ana/vertexTree");
+  TTree * tIso = (TTree*)f->Get("vertextree_iso_ana/vertexTree");
 
   std::vector< float > * zVtx_gen = 0;   
   unsigned int nVertices = 0;
@@ -25,6 +26,12 @@ void visualization(int eventNumber, std::string fileName, std::string tag = "", 
   bool trackHPVtx[300][300] = {0};
   float contaminationFracByWeight[300] = {0};
   int bestMatchGenByWeight[300] = {0};
+
+  unsigned int nVerticesIso = 0;
+  float zVtxIso[300] = {0};
+
+  tIso->SetBranchAddress("zVtx",&zVtxIso);
+  tIso->SetBranchAddress("nVertices",&nVerticesIso);
 
   t->SetBranchAddress("zVtx_gen",&zVtx_gen); 
   t->SetBranchAddress("nVertices",&nVertices);
@@ -38,15 +45,17 @@ void visualization(int eventNumber, std::string fileName, std::string tag = "", 
   t->SetBranchAddress("bestMatchGenByWeight",&bestMatchGenByWeight);
 
   t->GetEntry(eventNumber);
-  
+  tIso->GetEntry(eventNumber); 
+ 
   gStyle->SetOptStat(0);
   gStyle->SetPadTickX(1);
   gStyle->SetPadTickY(1);
 
   TCanvas * c1 =new TCanvas("c1","c1",1200,800);
   c1->SetBorderSize(0);
-  TPad * p1 = new TPad("p1","p1",0,0.2,1,1,0);
-  TPad * p2 = new TPad("p2","p2",0,0,1,0.2,0);
+  TPad * p1 = new TPad("p1","p1",0,0.3,1,1,0);
+  TPad * p2 = new TPad("p2","p2",0,0.2,1,0.3,0);
+  TPad * p3 = new TPad("p3","p3",0,0,1,0.2,0);
   c1->SetLineWidth(0);
   p1->SetBottomMargin(0);
   p1->SetLeftMargin(0.1);
@@ -57,9 +66,15 @@ void visualization(int eventNumber, std::string fileName, std::string tag = "", 
   p2->SetTopMargin(0);
   p2->SetLeftMargin(0.1);
   p2->SetRightMargin(0.05);
-  p2->SetBottomMargin(0.42);
+  p2->SetBottomMargin(0);
   p2->SetBorderSize(0);
   p2->Draw();
+  p3->SetTopMargin(0);
+  p3->SetLeftMargin(0.1);
+  p3->SetRightMargin(0.05);
+  p3->SetBottomMargin(0.42);
+  p3->SetBorderSize(0);
+  p3->Draw();
   p1->cd();
 
   TH1D * topDummy = new TH1D("topDummy",";z (cm); GenTop",1,-maxZ,maxZ);
@@ -69,7 +84,7 @@ void visualization(int eventNumber, std::string fileName, std::string tag = "", 
   topDummy->GetYaxis()->CenterTitle();
   topDummy->Draw("p");
   
-  p2->cd();
+  p3->cd();
   TH1D * botDummy = new TH1D("botDummy",";z (cm); Gen",1,-maxZ,maxZ);
   botDummy->Fill(0.001);
   botDummy->GetYaxis()->SetRangeUser(-0.1,0.1);
@@ -80,8 +95,13 @@ void visualization(int eventNumber, std::string fileName, std::string tag = "", 
   botDummy->GetYaxis()->SetLabelSize(0);
   botDummy->GetXaxis()->SetTitleSize(0.2);
   botDummy->GetXaxis()->SetLabelSize(0.2);
-  botDummy->Draw("p");
+  botDummy->DrawCopy("p");
   
+  p2->cd();
+  botDummy->GetYaxis()->SetTitleSize(0.23);
+  botDummy->GetYaxis()->SetTitle("Iso");
+  botDummy->Draw("p");
+  p3->cd();
 
   TMarker * m[300];
   TLine * l[300];
@@ -100,6 +120,26 @@ void visualization(int eventNumber, std::string fileName, std::string tag = "", 
     colorID.push_back(c);
     c++;
   }
+
+  p2->cd();
+  TMarker * mIso[300];
+  TLine * lIso[300];
+  std::vector< float > isoZ;
+  for(unsigned int i = 0; i<nVerticesIso; i++) isoZ.push_back(zVtxIso[i]);
+  std::sort(isoZ.begin(), isoZ.end());
+  c = 0;
+  for(unsigned int i = 0; i<isoZ.size(); i++){
+    mIso[i] = new TMarker(isoZ.at(i), 0, 8);
+    mIso[i]->SetMarkerColor(c%2+1);
+    mIso[i]->SetMarkerSize(1.4);
+    mIso[i]->Draw("same");
+    lIso[i] = new TLine(isoZ.at(i),-0.1,isoZ.at(i),0.1);
+    lIso[i]->SetLineColor(c%2 +1);
+    lIso[i]->SetLineStyle(2);
+    lIso[i]->Draw();
+    c++;
+  }
+
 
   p1->cd();
   TLine * lR[300];


### PR DESCRIPTION
Fixed a std::vector out-of-range bug caused by out-of-time pileup tracks.  Also added the isolated vtx collection to the tree producer and added the macro I use to visualize events.